### PR TITLE
JSX typecheck fixed

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "compact": false,
   "presets": [
-    ["es2015", {"loose": true, "modules": false}]
+    ["env", {"loose": true, "modules": false}]
   ],
   "plugins": [
     "transform-class-properties",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "Dominic Gannaway",
   "license": "MIT",
   "dependencies": {
+    "@types/react": "^16.0.38",
     "inferno": "^4.0.1"
   },
   "devDependencies": {
@@ -25,7 +26,7 @@
     "babel-plugin-syntax-object-rest-spread": "^6.13.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "clean-webpack-plugin": "^0.1.18",
     "html-webpack-plugin": "^2.30.1",
     "source-map-loader": "^0.2.3",

--- a/src/components/Incrementer.tsx
+++ b/src/components/Incrementer.tsx
@@ -31,7 +31,7 @@ export class Incrementer extends Component<Props, { value: number }> {
 			<div>
 				{this.props.name}
 				<button onClick={this.doMath}>Increment</button>
-				<Visualizer number={this.state.value + 'foobar'} />
+				<Visualizer value={this.state.value + 'foobar'} />
 			</div>
 		);
 	}

--- a/src/components/Visualizer.tsx
+++ b/src/components/Visualizer.tsx
@@ -3,6 +3,6 @@
  * This is example of Inferno functional component
  * Functional components provide great performance but does not have state
  */
-export function Visualizer({ number: number }) {
-	return <div className="visualizer">{number}</div>;
+export function Visualizer({ value }: { value: string }) {
+	return <div className="visualizer">{value}</div>;
 }

--- a/src/references.d.ts
+++ b/src/references.d.ts
@@ -1,0 +1,16 @@
+import { Component as ComponentOrigin } from 'inferno/core/component';
+import { InfernoInput as InfernoInputOrigin, InfernoChildren } from 'inferno/core/implementation';
+
+declare module 'inferno' {
+		export class Component<P, S> extends ComponentOrigin<P, S> {
+			public refs: {
+				[key: string]: any
+			};
+		}
+
+		export type InfernoInput = InfernoInputOrigin | JSX.Element;
+		export function render(
+			input: InfernoInput,
+			parentDom: Element | SVGAElement | DocumentFragment | HTMLElement | Node | null,
+			callback?: Function): InfernoChildren;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.2.2",
+	"version": "2.6.2",
 	"compilerOptions": {
 		"target": "es6",
 		"module": "es6",
@@ -12,9 +12,6 @@
 			"es6",
 			"es7",
 			"dom"
-		],
-		"types": [
-			"inferno"
 		],
 		"jsx": "preserve",
 		"noUnusedLocals": true,

--- a/tslint.json
+++ b/tslint.json
@@ -18,7 +18,7 @@
 			"object-literal-sort-keys": true,
 			"one-variable-per-declaration": [true, "ignore-for-loop"],
 			"only-arrow-functions": [false],
-			"ordered-imports": true,
+			"ordered-imports": false,
 			"prefer-const": true,
 			"prefer-for-of": false,
 			"quotemark": [ true, "single", "jsx-double" ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,13 +17,13 @@ module.exports = {
 	module: {
 		loaders: [
 			{
-				test: /\.tsx?$/, 						  // All ts and tsx files will be process by
+				test: /\.tsx?$/, 						  						// All ts and tsx files will be process by
 				loaders: [ 'babel-loader', 'ts-loader' ], // first babel-loader, then ts-loader
 				exclude: /node_modules/                   // ignore node_modules
 			}, {
 				test: /\.jsx?$/,                          // all js and jsx files will be processed by
 				loader: 'babel-loader',                   // babel-loader
-				exclude: /node_modules/                  // ignore node_modules
+				exclude: /node_modules/                 	// ignore node_modules
 			}
 		]
 	},


### PR DESCRIPTION
Hello! I have fixed #8 issue with simple solution. I have included react jsx types (`@types/react` package) and made small module redeclaration (`./src/references.d.ts`). Now Typescript correctly checking TSX with Inferno.
It also works great with 3rd-party libraries, written for React. In my own educational project I have used some of them ([Formik](https://github.com/jaredpalmer/formik), [React-S-Alert(https://github.com/juliancwirko/react-s-alert), [React-Numeric-Input](https://www.npmjs.com/package/react-numeric-input)) and all of them worked good with Inferno and Typescript. Props types also checked correctly. For example, with alternative [JSX types definition](https://github.com/rendall/inferno-jsx-type-definitions/) I could not build the package because of wrong type error.